### PR TITLE
fix: clear stale results on input mode change

### DIFF
--- a/frontend/App.vue
+++ b/frontend/App.vue
@@ -17,6 +17,21 @@ let sequence = 0;
 
 const findSpecimen = (id: string) => specimens.value.find((s) => s.id === id);
 
+const cleanupSpecimen = (specimen: IsccWeb.Specimen) => {
+  const mediaId = specimen.metadata?.media_id;
+  if (mediaId && specimen.status === "done") {
+    apiService.deleteMedia(mediaId).catch(() => undefined);
+  }
+  if (specimen.previewUrl && typeof URL.revokeObjectURL === "function") {
+    URL.revokeObjectURL(specimen.previewUrl);
+  }
+};
+
+const clearSpecimens = () => {
+  for (const specimen of specimens.value) cleanupSpecimen(specimen);
+  specimens.value = [];
+};
+
 const baseSpecimen = (partial: Partial<IsccWeb.Specimen> & Pick<IsccWeb.Specimen, "id" | "kind" | "label">) => {
   const specimen: IsccWeb.Specimen = {
     status: "processing",
@@ -160,13 +175,7 @@ const onEmbed = async (specimen: IsccWeb.Specimen, formData: IsccWeb.MetadataFor
 };
 
 const onRemove = (specimen: IsccWeb.Specimen) => {
-  const mediaId = specimen.metadata?.media_id;
-  if (mediaId && specimen.status === "done") {
-    apiService.deleteMedia(mediaId).catch(() => undefined);
-  }
-  if (specimen.previewUrl && typeof URL.revokeObjectURL === "function") {
-    URL.revokeObjectURL(specimen.previewUrl);
-  }
+  cleanupSpecimen(specimen);
   specimens.value = specimens.value.filter((s) => s.id !== specimen.id);
   for (const other of specimens.value) {
     if (other.compareWithId === specimen.id) {
@@ -220,6 +229,7 @@ const compareOptionsFor = (specimen: IsccWeb.Specimen) =>
             @upload-success="onUploadSuccess"
             @text-submit="onTextSubmit"
             @code-submit="onCodeSubmit"
+            @mode-change="clearSpecimens"
           )
         .copy-col
           .iso-badge

--- a/frontend/components/IntakeCard.vue
+++ b/frontend/components/IntakeCard.vue
@@ -10,6 +10,8 @@ import { normalizeIscc } from "../lib/iscc";
 import { apiService } from "../services/api.service";
 import UiIcon from "./UiIcon.vue";
 
+type IntakeMode = "file" | "text" | "code";
+
 const emit = defineEmits<{
   (
     e: "file-added",
@@ -25,9 +27,10 @@ const emit = defineEmits<{
   (e: "upload-success", fileId: string, metadata: Api.IsccMetadata): void;
   (e: "text-submit", text: string, options: { semantic: boolean; granular: boolean }): void;
   (e: "code-submit", iscc: string): void;
+  (e: "mode-change", mode: IntakeMode): void;
 }>();
 
-const tab = ref<"file" | "text" | "code">("file");
+const tab = ref<IntakeMode>("file");
 const semantic = ref(false);
 const granular = ref(false);
 const text = ref("");
@@ -93,8 +96,14 @@ onUnmounted(() => {
   uppy.destroy();
 });
 
+const setTab = (next: IntakeMode) => {
+  if (tab.value === next) return;
+  tab.value = next;
+  emit("mode-change", next);
+};
+
 const addFiles = (list: FileList) => {
-  tab.value = "file";
+  setTab("file");
   uppy.addFiles(Array.from(list).map((f) => ({ name: f.name, type: f.type, data: f })));
 };
 
@@ -173,21 +182,21 @@ const submitCode = () => {
     button.intake-tab(
       type="button"
       :class="{ active: tab === 'file' }"
-      @click="tab = 'file'"
+      @click="setTab('file')"
     )
       UiIcon(name="upload" :size="15")
       span Media file
     button.intake-tab(
       type="button"
       :class="{ active: tab === 'text' }"
-      @click="tab = 'text'"
+      @click="setTab('text')"
     )
       UiIcon(name="type" :size="15")
       span Plain text
     button.intake-tab(
       type="button"
       :class="{ active: tab === 'code' }"
-      @click="tab = 'code'"
+      @click="setTab('code')"
     )
       UiIcon(name="search" :size="15")
       span ISCC code

--- a/frontend/tests/app.spec.ts
+++ b/frontend/tests/app.spec.ts
@@ -66,6 +66,22 @@ describe("App", () => {
     wrapper.unmount();
   });
 
+  it("clears stale result cards when the active input mode changes", async () => {
+    vi.mocked(apiService.explainIscc).mockRejectedValue(new Error("400: bad code"));
+    const wrapper = mountApp();
+    const intake = wrapper.findComponent(IntakeCard);
+
+    intake.vm.$emit("code-submit", "ISCC:KACYPXW445FTYNJ3");
+    await flushPromises();
+    expect(wrapper.findComponent(ResultCard).find(".alert-strip").text()).toContain("400: bad code");
+
+    intake.vm.$emit("mode-change", "text");
+    await flushPromises();
+    expect(wrapper.findComponent(ResultCard).exists()).toBe(false);
+    expect(wrapper.findComponent(EducationStrip).exists()).toBe(true);
+    wrapper.unmount();
+  });
+
   it("docks a second specimen for comparison and ejects it again", async () => {
     const wrapper = mountApp();
     const intake = wrapper.findComponent(IntakeCard);

--- a/frontend/tests/intake-card.spec.ts
+++ b/frontend/tests/intake-card.spec.ts
@@ -26,6 +26,16 @@ describe("IntakeCard", () => {
     wrapper.unmount();
   });
 
+  it("emits mode changes when switching tabs", async () => {
+    const wrapper = mount(IntakeCard);
+    await tabButton(wrapper, "Plain text").trigger("click");
+    await tabButton(wrapper, "ISCC code").trigger("click");
+    await tabButton(wrapper, "ISCC code").trigger("click");
+
+    expect(wrapper.emitted("mode-change")).toEqual([["text"], ["code"]]);
+    wrapper.unmount();
+  });
+
   it("generates from plain text with the current toggle state", async () => {
     const wrapper = mount(IntakeCard);
     await tabButton(wrapper, "Plain text").trigger("click");


### PR DESCRIPTION
## Summary
- emit an intake mode-change event when users switch tabs
- clear existing result cards on mode changes so stale decode errors are not shown under another input mode
- reuse result cleanup for media deletion/object URL revocation

## Test Plan
- `corepack pnpm build`
- `corepack pnpm test`

Fixes #55