### PR TITLE
Release v0.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main, v0.3.0]
+    branches: [main, v0.3.1]
   workflow_dispatch:
 
 # Cancel stale in-flight PR runs; let branch-push runs complete so :main publishing isn't cancelled.
@@ -147,6 +147,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          # CPU stage only: the GPU stage is last (default) but is huge and never smoke-tested here.
+          target: prod-runtime
           load: true
           tags: iscc-web:smoke
           cache-from: type=gha
@@ -201,12 +203,61 @@ jobs:
           tags: |
             type=ref,event=branch
 
-      - name: Build and push
+      - name: Build and push (CPU :main)
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
+          # Pin the CPU stage so the plain :main tag never gets the GPU (last/default) stage.
+          target: prod-runtime
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
+
+  # Build the opt-in CUDA image. Runs on pushes (main + the working branch) and manual dispatch,
+  # NEVER on PRs — the ~3 GB CUDA base is too costly for every PR. Build-only proves the image
+  # compiles and its imports resolve (the in-image model bake runs Python against the GPU venv);
+  # functional GPU inference is verified manually on the GPU host, not in CI (runners have no GPU).
+  # Pushes :main-gpu only on main; on the working branch it builds without pushing (verification).
+  docker-gpu:
+    name: Docker GPU (build; push :main-gpu on main)
+    if: github.event_name != 'pull_request'
+    needs: [test, lint, frontend, docker]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}
+          flavor: |
+            latest=false
+            suffix=-gpu
+          tags: |
+            type=ref,event=branch
+
+      - name: Build (and push :main-gpu on main)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: prod-runtime-gpu
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Separate gha cache scope so the CUDA layers never evict the CPU image's cache.
+          cache-from: type=gha,scope=gpu
+          cache-to: type=gha,mode=max,scope=gpu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,27 +30,28 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen
 
-      # Same iscc-sct model cache plumbing as ci.yml — a no-op until iscc-sdk[sct] lands.
-      - name: Cache iscc-sct model
+      # Cache the iscc-sct/iscc-sci ONNX models across runs (same plumbing as ci.yml). Parallel
+      # pytest-xdist workers would otherwise race on the download and can corrupt the ONNX file.
+      - name: Cache semantic-code models
         uses: actions/cache@v5
         with:
           path: |
             ~/.local/share/iscc-sct
+            ~/.local/share/iscc-sci
             ~\AppData\Local\iscc\iscc-sct
-          key: iscc-sct-model-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+            ~\AppData\Local\iscc\iscc-sci
+          key: iscc-models-${{ runner.os }}-${{ hashFiles('uv.lock') }}
           restore-keys: |
-            iscc-sct-model-${{ runner.os }}-
+            iscc-models-${{ runner.os }}-
 
-      - name: Pre-download iscc-sct model (serial, before parallel tests)
+      - name: Pre-download semantic-code models (serial, before parallel tests)
         run: |
-          mkdir -p ~/.local/share/iscc-sct  # ensure at least one cache path exists
           uv run python - <<'EOF'
-          try:
-              import iscc_sct.code_semantic_text as sct
-              sct.model()
-              print("iscc-sct model ready")
-          except ImportError:
-              print("iscc-sct not installed - nothing to pre-download")
+          import iscc_sct.utils
+          import iscc_sci.utils
+          iscc_sct.utils.get_model()
+          iscc_sci.utils.get_model()
+          print("semantic-code models ready")
           EOF
 
       - name: Run tests  # local parity: uv run poe test
@@ -74,6 +75,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # --- CPU image (default, slim base): :X.Y.Z and :X.Y ---
       - id: meta
         uses: docker/metadata-action@v6
         with:
@@ -85,13 +87,40 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
-      - name: Build and push
+      - name: Build and push (CPU)
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
+          # Pin the CPU stage: appending the GPU stage makes it the last (default) stage, so an
+          # untargeted build would silently publish the ~3 GB CUDA image under the plain tags.
+          target: prod-runtime
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # --- GPU image (opt-in CUDA base): :X.Y.Z-gpu and :X.Y-gpu ---
+      - id: meta-gpu
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}
+          flavor: |
+            latest=false
+            suffix=-gpu
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push (GPU)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: prod-runtime-gpu
+          push: true
+          tags: ${{ steps.meta-gpu.outputs.tags }}
+          labels: ${{ steps.meta-gpu.outputs.labels }}
+          cache-from: type=gha,scope=gpu
+          cache-to: type=gha,mode=max,scope=gpu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.1] - 2026-06-14
+
+- Added an opt-in GPU Docker image variant published under `-gpu` tags (`:0.3.1-gpu`,
+    `:0.3-gpu`, `:main-gpu`) on a CUDA base that runs the experimental semantic codes on an
+    NVIDIA GPU; the default image stays the lean CPU `python:3.13-slim` build
+- Tightened client-side ISCC code input validation in the demo frontend decoder
+
 ## [0.3.0] - 2026-06-12
 
 - Added optional semantic ISCC-UNITs for text and image content via the `semantic` query

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,10 @@ COPY pyproject.toml uv.lock /app/
 
 FROM builder AS prod-build
 
-# Install dependencies into /app/.venv
-RUN uv sync --frozen --no-dev --no-install-project
+# Install dependencies into /app/.venv. --extra cpu pulls the CPU onnxruntime variant of
+# iscc-sct/iscc-sci (post-split, no extra means no onnxruntime at all). The GPU image uses
+# --extra gpu in its own stage; the two onnxruntime variants must never co-resolve.
+RUN uv sync --frozen --no-dev --no-install-project --extra cpu
 
 # Fetch content processing tools (ffmpeg, ffprobe, fpcalc) into /root/.local/share/iscc-sdk
 RUN /app/.venv/bin/iscc-sdk install
@@ -79,6 +81,61 @@ COPY --from=prod-build /app /app
 COPY --from=frontend-build /app/iscc_web/static/dist /app/iscc_web/static/dist
 
 WORKDIR /app
+
+EXPOSE 8000/tcp
+
+CMD ["gunicorn", "iscc_web.main:app", "-k", "uvicorn_worker.UvicornWorker"]
+
+#
+# prod-runtime-gpu (opt-in CUDA variant)
+#
+# Single combined build+runtime stage on the CUDA base: a multi-stage split saves almost nothing
+# on a ~3 GB base and would force copying a uv-managed Python across stages (fragile venv symlinks).
+# This stage is NOT the default — Docker builds the last stage when no target is given, so every
+# CPU build invocation must pass `target: prod-runtime` (see release.yml / ci.yml). NVIDIA driver +
+# nvidia-container-toolkit + `--gpus all` are needed for GPU; without them it falls back to CPU.
+#
+FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04 AS prod-runtime-gpu
+
+LABEL org.opencontainers.image.source=https://github.com/iscc/iscc-web
+
+# ca-certificates: the CUDA base ships none (python:3.13-slim does); the model/tool fetch below plus
+# runtime HTTPS (Sentry, URL fetches) need TLS trust. libexpat1: the exiv2 wheel's native lib.
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y libexpat1 ca-certificates && \
+  rm -rf /var/lib/apt/lists
+
+# Disable stdout/stderr buffering, can cause issues with Docker logs
+ENV PYTHONUNBUFFERED=1
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENV VIRTUAL_ENV=/app/.venv
+
+ENV ISCC_WEB_ENVIRONMENT=production
+ENV PORT=8000
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /uvx /bin/
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock /app/
+
+# The CUDA base ships system Python 3.12; the lock targets 3.13. Use a uv-managed 3.13.
+RUN uv python install 3.13
+
+# Install dependencies into /app/.venv with the GPU onnxruntime variant.
+RUN uv sync --frozen --no-dev --no-install-project --extra gpu --python 3.13
+
+# Fetch content processing tools (ffmpeg, ffprobe, fpcalc) into /root/.local/share/iscc-sdk
+RUN /app/.venv/bin/iscc-sdk install
+
+# Bake semantic-code ONNX models so containers start warm AND prove the GPU image's imports resolve
+# in the final image (the build host has no GPU; get_model() only downloads — no CUDA session).
+RUN /app/.venv/bin/python -c "import iscc_sct.utils, iscc_sci.utils; iscc_sct.utils.get_model(); iscc_sci.utils.get_model()"
+
+COPY . /app/
+COPY --from=frontend-build /app/iscc_web/static/dist /app/iscc_web/static/dist
 
 EXPOSE 8000/tcp
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ with `main` and semver tags):
 docker run -p 8000:8000 ghcr.io/iscc/iscc-web:main
 ```
 
+Each tag also has an opt-in `-gpu` variant (e.g. `:main-gpu`) on a CUDA base that runs the
+experimental semantic codes on an NVIDIA GPU. Most deployments want the smaller default image;
+see the [deployment guide](https://web.iscc.codes/howto/deployment/) for GPU requirements.
+
 ## Overview
 
 <img align="left" width="200" src="docs/assets/iscc-web-rest-api.jpg?raw=true">

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -6,6 +6,13 @@ description: Release history of the iscc-web microservice.
 
 # Changelog
 
+## [0.3.1] - 2026-06-14
+
+- Added an opt-in GPU Docker image variant published under `-gpu` tags (`:0.3.1-gpu`,
+    `:0.3-gpu`, `:main-gpu`) on a CUDA base that runs the experimental semantic codes on an
+    NVIDIA GPU; the default image stays the lean CPU `python:3.13-slim` build
+- Tightened client-side ISCC code input validation in the demo frontend decoder
+
 ## [0.3.0] - 2026-06-12
 
 - Added optional semantic ISCC-UNITs for text and image content via the `semantic` query

--- a/docs/howto/deployment.md
+++ b/docs/howto/deployment.md
@@ -26,14 +26,32 @@ Production images are published to the GitHub Container Registry as
 
 ### Image tags
 
-| Tag     | Example                       | Published                                |
-| ------- | ----------------------------- | ---------------------------------------- |
-| `main`  | `ghcr.io/iscc/iscc-web:main`  | On every push to `main` after CI passes  |
-| `X.Y.Z` | `ghcr.io/iscc/iscc-web:0.3.0` | On GitHub releases — immutable           |
-| `X.Y`   | `ghcr.io/iscc/iscc-web:0.3`   | On GitHub releases — tracks latest patch |
+| Tag     | Example                           | Published                                 |
+| ------- | --------------------------------- | ----------------------------------------- |
+| `main`  | `ghcr.io/iscc/iscc-web:main`      | On every push to `main` after CI passes   |
+| `X.Y.Z` | `ghcr.io/iscc/iscc-web:0.3.0`     | On GitHub releases — immutable            |
+| `X.Y`   | `ghcr.io/iscc/iscc-web:0.3`       | On GitHub releases — tracks latest patch  |
+| `*-gpu` | `ghcr.io/iscc/iscc-web:0.3.0-gpu` | GPU variant of each tag above (see below) |
 
 No `:latest` tag is published. Pin a semver tag for reproducible deployments, or use `:main` to
 follow the development branch.
+
+### GPU image (opt-in)
+
+Every tag also ships a `-gpu` variant (`:0.3.0-gpu`, `:0.3-gpu`, `:main-gpu`) built on the
+`nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04` base with the CUDA build of onnxruntime. It runs
+the experimental semantic codes (iscc-sct text, iscc-sci image) on an NVIDIA GPU instead of the
+CPU. The default (non-`-gpu`) image is what most deployments want — only reach for `-gpu` if you
+serve semantic codes at volume.
+
+The GPU image needs an NVIDIA driver, the
+[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/),
+and the container started with GPU access (`docker run --gpus all …`, or a Compose `deploy.resources`
+device reservation). On a host without a usable GPU it still runs but falls back to CPU inference —
+with no benefit over the much smaller default image (the CUDA base is ~3 GB).
+
+GPU deployment specifics (Compose device reservation, worker sizing, on-box verification) live in
+the [`iscc-infra`](https://github.com/iscc/iscc-infra) repository rather than being duplicated here.
 
 ## Deploy with Docker Compose
 

--- a/frontend/components/IntakeCard.vue
+++ b/frontend/components/IntakeCard.vue
@@ -158,7 +158,7 @@ const codeHint = computed(() =>
   codeState.value === "empty"
     ? "validates as you type — prefix optional"
     : codeState.value === "valid"
-      ? "looks like a valid ISCC"
+      ? "ready to decode"
       : "not a valid ISCC yet",
 );
 const submitCode = () => {

--- a/frontend/lib/iscc.ts
+++ b/frontend/lib/iscc.ts
@@ -88,14 +88,122 @@ export function pctColor(pct: number): string {
   return pct >= 80 ? "#a6db50" : pct >= 55 ? "#ffc300" : "#f56169";
 }
 
-export const ISCC_PATTERN = /^ISCC:[A-Z2-7]{10,73}$/;
+export const ISCC_PATTERN = /^ISCC:[A-Z2-7]{10,68}$/;
+
+const ISCC_PREFIXES = new Set([
+  "AA",
+  "CA",
+  "CE",
+  "CI",
+  "CM",
+  "CQ",
+  "EA",
+  "EE",
+  "EI",
+  "EM",
+  "EQ",
+  "GA",
+  "IA",
+  "KA",
+  "KE",
+  "KI",
+  "KM",
+  "KQ",
+  "KU",
+  "KY",
+  "K4",
+  "MA",
+  "ME",
+  "MI",
+  "MM",
+  "OA",
+]);
+const ISCC_COMPOSITE_UNITS = [0, 1, 1, 2, 1, 2, 2, 3];
+const INVALID_BASE32_REMAINDERS = new Set([1, 3, 6]);
+
+const base32Bits = (code: string): number[] | null => {
+  const body = code.split(":")[1] ?? "";
+  if (INVALID_BASE32_REMAINDERS.has(body.length % 8)) return null;
+  const bits: number[] = [];
+  for (const char of body) {
+    const value = BASE32.indexOf(char);
+    if (value < 0) return null;
+    for (let bit = 4; bit >= 0; bit--) bits.push((value >> bit) & 1);
+  }
+  bits.length = Math.floor(bits.length / 8) * 8;
+  return bits;
+};
+
+const bitsToInt = (bits: number[], start: number, length: number) => {
+  let value = 0;
+  for (let idx = start; idx < start + length; idx++) value = (value << 1) | bits[idx];
+  return value;
+};
+
+const decodeVarnibble = (bits: number[], offset: number): [number, number] | null => {
+  const remaining = bits.length - offset;
+  if (remaining < 4) return null;
+  if (bits[offset] === 0) return [bitsToInt(bits, offset, 4), offset + 4];
+  if (remaining >= 8 && bits[offset + 1] === 0) return [bitsToInt(bits, offset + 2, 6) + 8, offset + 8];
+  if (remaining >= 12 && bits[offset + 1] === 1 && bits[offset + 2] === 0) {
+    return [bitsToInt(bits, offset + 3, 9) + 72, offset + 12];
+  }
+  if (remaining >= 16 && bits[offset + 1] === 1 && bits[offset + 2] === 1 && bits[offset + 3] === 0) {
+    return [bitsToInt(bits, offset + 4, 12) + 584, offset + 16];
+  }
+  return null;
+};
+
+const expectedPayloadBytes = (mainType: number, subType: number, length: number): number | null => {
+  if ([0, 1, 2, 3, 4, 7].includes(mainType)) {
+    const bytes = (length + 1) * 4;
+    return bytes <= 40 ? bytes : null;
+  }
+  if (mainType === 5) {
+    if (subType === 7) return 32;
+    const unitCount = ISCC_COMPOSITE_UNITS[length];
+    return unitCount === undefined ? null : unitCount * 8 + 16;
+  }
+  if (mainType === 6) return length <= 4 ? length + 8 : null;
+  return null;
+};
+
+const hasSupportedVersion = (mainType: number, version: number) =>
+  version === 0 || (mainType === 6 && version === 1);
+
+/** True when an ISCC passes the same canonical prefix/header/length checks as iscc-core. */
+export function isValidIscc(code: string): boolean {
+  if (!ISCC_PATTERN.test(code)) return false;
+  const body = code.split(":")[1];
+  if (!ISCC_PREFIXES.has(body.slice(0, 2))) return false;
+  const bits = base32Bits(code);
+  if (!bits) return false;
+
+  let offset = 0;
+  const header: number[] = [];
+  for (let idx = 0; idx < 4; idx++) {
+    const decoded = decodeVarnibble(bits, offset);
+    if (!decoded) return false;
+    header.push(decoded[0]);
+    offset = decoded[1];
+  }
+
+  const [mainType, subType, version, length] = header;
+  if (!hasSupportedVersion(mainType, version)) return false;
+  const expectedBytes = expectedPayloadBytes(mainType, subType, length);
+  if (expectedBytes === null) return false;
+
+  let payloadBits = bits.length - offset;
+  if (payloadBits % 8 && bits.slice(offset, offset + 4).every((bit) => bit === 0)) payloadBits -= 4;
+  return Math.ceil(payloadBits / 8) === expectedBytes;
+}
 
 /** Canonical form of a user-entered ISCC (trimmed, uppercased, prefixed) or null if invalid. */
 export function normalizeIscc(input: string): string | null {
   let code = input.trim().toUpperCase();
   if (!code) return null;
   if (!code.startsWith("ISCC:")) code = `ISCC:${code}`;
-  return ISCC_PATTERN.test(code) ? code : null;
+  return isValidIscc(code) ? code : null;
 }
 
 /** Human-readable byte count: 53256 -> "52.0 KB". */

--- a/frontend/tests/intake-card.spec.ts
+++ b/frontend/tests/intake-card.spec.ts
@@ -56,11 +56,12 @@ describe("IntakeCard", () => {
     expect(wrapper.find(".valid-dot").classes()).toContain("invalid");
     expect(button.attributes("disabled")).toBeDefined();
 
-    await input.setValue("kacypxw445ftynj3cysxhafjma2hu");
+    await input.setValue("aaawn77f73na44d7");
     expect(wrapper.find(".valid-dot").classes()).toContain("valid");
+    expect(wrapper.find(".input-note").text()).toBe("ready to decode");
     await button.trigger("click");
 
-    expect(wrapper.emitted("code-submit")).toEqual([["ISCC:KACYPXW445FTYNJ3CYSXHAFJMA2HU"]]);
+    expect(wrapper.emitted("code-submit")).toEqual([["ISCC:AAAWN77F73NA44D7"]]);
     wrapper.unmount();
   });
 

--- a/frontend/tests/iscc.spec.ts
+++ b/frontend/tests/iscc.spec.ts
@@ -5,6 +5,7 @@ import {
   type UnitKind,
   compareUnits,
   formatBytes,
+  isValidIscc,
   matchPercent,
   normalizeIscc,
   pctColor,
@@ -67,14 +68,22 @@ describe("pctColor", () => {
 
 describe("normalizeIscc", () => {
   it("canonicalizes valid input", () => {
-    expect(normalizeIscc("ISCC:KACYPXW445FTYNJ3")).toBe("ISCC:KACYPXW445FTYNJ3");
-    expect(normalizeIscc("kacypxw445ftynj3")).toBe("ISCC:KACYPXW445FTYNJ3");
-    expect(normalizeIscc("  iscc:kacypxw445ftynj3  ")).toBe("ISCC:KACYPXW445FTYNJ3");
+    expect(normalizeIscc("ISCC:AAAWN77F73NA44D7")).toBe("ISCC:AAAWN77F73NA44D7");
+    expect(normalizeIscc("aaawn77f73na44d7")).toBe("ISCC:AAAWN77F73NA44D7");
+    expect(normalizeIscc("  iscc:aaawn77f73na44d7  ")).toBe("ISCC:AAAWN77F73NA44D7");
+  });
+
+  it("validates canonical ISCC prefixes, headers and payload lengths", () => {
+    expect(isValidIscc("ISCC:AAAWN77F73NA44D7")).toBe(true);
+    expect(isValidIscc("ISCC:KAAZEB4IFIVIXYL7NE7IGL6MTNBKH2UPCY63HBUCSI")).toBe(true);
+    expect(isValidIscc("ISCC:NOTAREALCODE")).toBe(false);
+    expect(isValidIscc("ISCC:KACYPXW445FTYNJ3")).toBe(false);
   });
 
   it("rejects invalid input", () => {
     expect(normalizeIscc("")).toBeNull();
     expect(normalizeIscc("not an iscc")).toBeNull();
+    expect(normalizeIscc("ISCC:NOTAREALCODE")).toBeNull();
     expect(normalizeIscc("ISCC:ABC")).toBeNull(); // too short
     expect(normalizeIscc("ISCC:" + "A".repeat(74))).toBeNull(); // too long
     expect(normalizeIscc("ISCC:KACY01")).toBeNull(); // 0 and 1 are not base32

--- a/iscc_web/__init__.py
+++ b/iscc_web/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 from iscc_web.options import *
 from iscc_web.main import *
 from iscc_web.api.media import *

--- a/iscc_web/static/docs/openapi.yaml
+++ b/iscc_web/static/docs/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: ISCC-WEB Generator API
   description: Simple ISCC Generator Service
-  version: 0.3.0
+  version: 0.3.1
 servers:
 - url: /api/v1
 tags:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,13 @@ dependencies = [
     "watchfiles>=0.21",
 ]
 
+[project.optional-dependencies]
+# onnxruntime now lives in the cpu|gpu extras of iscc-sct/iscc-sci (variant wheels that clobber
+# each other in site-packages). Pick exactly one per built image; never both. iscc-sdk[sct,sci]
+# forwards the bare libs; these extras attach the onnxruntime variant and the >=0.2.0/>=0.3.0 floor.
+cpu = ["iscc-sct[cpu]>=0.2.0", "iscc-sci[cpu]>=0.3.0"]
+gpu = ["iscc-sct[gpu]>=0.2.0", "iscc-sci[gpu]>=0.3.0"]
+
 [project.urls]
 Homepage = "https://github.com/iscc/iscc-web"
 
@@ -49,10 +56,18 @@ dev = [
     "prek>=0.2.9",
     "radon>=6.0.1",
     "zensical>=0.0.21",
+    # CPU onnxruntime for local dev/tests so `uv sync` runs semantic inference without the gpu extra.
+    "onnxruntime",
 ]
 
 [tool.uv]
 default-groups = "all"
+conflicts = [
+    # The two image variants: cpu and gpu pull mutually-clobbering onnxruntime variant wheels.
+    [{ extra = "cpu" }, { extra = "gpu" }],
+    # dev brings CPU onnxruntime; never co-resolve it with the gpu extra's onnxruntime-gpu.
+    [{ group = "dev" }, { extra = "gpu" }],
+]
 
 [tool.uv.build-backend]
 module-name = "iscc_web"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iscc-web"
-version = "0.3.0"
+version = "0.3.1"
 description = "ISCC - Generator Web Application"
 authors = [{ name = "Titusz", email = "tp@py7.de" }]
 requires-python = ">=3.13"

--- a/tests/test_iscc_web.py
+++ b/tests/test_iscc_web.py
@@ -2,4 +2,4 @@ from iscc_web import __version__
 
 
 def test_version():
-    assert __version__ == "0.3.0"
+    assert __version__ == "0.3.1"

--- a/uv.lock
+++ b/uv.lock
@@ -2,9 +2,19 @@ version = 1
 revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version < '3.14'",
+    "extra != 'extra-8-iscc-web-cpu' and extra == 'extra-8-iscc-web-gpu' and extra != 'group-8-iscc-web-dev'",
+    "python_full_version >= '3.14' and extra == 'extra-8-iscc-web-cpu' and extra != 'extra-8-iscc-web-gpu'",
+    "python_full_version < '3.14' and extra == 'extra-8-iscc-web-cpu' and extra != 'extra-8-iscc-web-gpu'",
+    "python_full_version >= '3.14' and extra != 'extra-8-iscc-web-cpu' and extra != 'extra-8-iscc-web-gpu'",
+    "python_full_version < '3.14' and extra != 'extra-8-iscc-web-cpu' and extra != 'extra-8-iscc-web-gpu'",
 ]
+conflicts = [[
+    { package = "iscc-web", extra = "cpu" },
+    { package = "iscc-web", extra = "gpu" },
+], [
+    { package = "iscc-web", extra = "gpu" },
+    { package = "iscc-web", group = "dev" },
+]]
 
 [[package]]
 name = "aiofile"
@@ -169,7 +179,7 @@ dependencies = [
     { name = "guardpost" },
     { name = "h11" },
     { name = "h2" },
-    { name = "httptools", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "httptools", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-8-iscc-web-cpu' and extra == 'extra-8-iscc-web-gpu') or (extra == 'extra-8-iscc-web-gpu' and extra == 'group-8-iscc-web-dev')" },
     { name = "itsdangerous" },
     { name = "rodi" },
 ]
@@ -348,7 +358,7 @@ name = "click"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-8-iscc-web-cpu' and extra == 'extra-8-iscc-web-gpu') or (extra == 'extra-8-iscc-web-gpu' and extra == 'group-8-iscc-web-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
@@ -738,7 +748,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-8-iscc-web-cpu' and extra == 'extra-8-iscc-web-gpu') or (extra == 'extra-8-iscc-web-gpu' and extra == 'group-8-iscc-web-dev')" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
@@ -887,24 +897,31 @@ wheels = [
 
 [[package]]
 name = "iscc-sci"
-version = "0.2.0"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
     { name = "loguru" },
-    { name = "onnxruntime" },
     { name = "pillow" },
     { name = "platformdirs" },
     { name = "pydantic-settings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/37/a1e283c4915f010012f00aaab3d3d0568b8de9810467066f0351443adc6a/iscc_sci-0.2.0.tar.gz", hash = "sha256:edf540f4900e1c777fb9c6d9ae90fff091907f05b2b3a83478cd36ee31491ba0", size = 11825, upload-time = "2025-04-28T19:03:46.486Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/e3/3c899244e6e04789a1d0af3920b07846e398b25aeb5476f65e97de3841d9/iscc_sci-0.3.0.tar.gz", hash = "sha256:68f85086dccb0e4433a5601f73c66daf8e50e19df8cba4522853a0437283ea79", size = 8833, upload-time = "2026-06-14T16:10:17.002Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/be/5725dd11804cefb0799165ca3270f7b87531dde14947d66f533a1f5053bc/iscc_sci-0.2.0-py3-none-any.whl", hash = "sha256:9ca00161a8df0a34811bc01d3ae33babd1edff6b2135083566cee7f94bc46178", size = 13613, upload-time = "2025-04-28T19:03:45.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cd/32c16d1b87c47195c8943332705ab3bd29e357f355040bbaa2bf732f84fb/iscc_sci-0.3.0-py3-none-any.whl", hash = "sha256:5ddf3d50bb078eec9e26bce905c4786a227dd09726d1b802bd880bd4973a37a2", size = 10205, upload-time = "2026-06-14T16:10:17.776Z" },
+]
+
+[package.optional-dependencies]
+cpu = [
+    { name = "onnxruntime" },
+]
+gpu = [
+    { name = "onnxruntime-gpu" },
 ]
 
 [[package]]
 name = "iscc-sct"
-version = "0.1.4"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -912,7 +929,6 @@ dependencies = [
     { name = "charset-normalizer" },
     { name = "loguru" },
     { name = "numpy" },
-    { name = "onnxruntime" },
     { name = "platformdirs" },
     { name = "pybase64" },
     { name = "pydantic" },
@@ -921,9 +937,17 @@ dependencies = [
     { name = "semantic-text-splitter" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/e4/75f029d8faeed9b08985d8d1c86597758b91c5c9ecb63840ebfbd13bcc6b/iscc_sct-0.1.4.tar.gz", hash = "sha256:e426ef89d9dc7c0aef02a511a543d1d0d3de09383f4b91df485ecfe1fc019922", size = 3553961, upload-time = "2025-04-24T16:26:30.594Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/d1/7c97139c1494703df13c26957d08e267432fc7b6970f498e3e454eb4d28b/iscc_sct-0.2.0.tar.gz", hash = "sha256:46e9710e517ef43daefb81999bc7cab5249f19544a146313220bfeb0ab228492", size = 3673921, upload-time = "2026-06-14T19:13:08.592Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/66/b924d77539a1bdef71fe5b98d821b910702fcab89bfd058817348c893882/iscc_sct-0.1.4-py3-none-any.whl", hash = "sha256:1966698ee5142afb00605cbb76c20cf6d73fe47d786dc72363eca77ed260cbb5", size = 3578513, upload-time = "2025-04-24T16:26:22.49Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/42/9a0f89bca0b3e446ad838bb894f04bae03168034e1caf8aa3e73c48449d4/iscc_sct-0.2.0-py3-none-any.whl", hash = "sha256:ac6fe1d1a36125749c1437735a8dd947e72e69227d8fefb2e3b3a87d34182936", size = 3673713, upload-time = "2026-06-14T19:13:10.082Z" },
+]
+
+[package.optional-dependencies]
+cpu = [
+    { name = "onnxruntime" },
+]
+gpu = [
+    { name = "onnxruntime-gpu" },
 ]
 
 [[package]]
@@ -1005,10 +1029,21 @@ dependencies = [
     { name = "xxhash" },
 ]
 
+[package.optional-dependencies]
+cpu = [
+    { name = "iscc-sci", extra = ["cpu"], marker = "extra == 'extra-8-iscc-web-cpu' or (extra == 'extra-8-iscc-web-gpu' and extra == 'group-8-iscc-web-dev')" },
+    { name = "iscc-sct", extra = ["cpu"], marker = "extra == 'extra-8-iscc-web-cpu' or (extra == 'extra-8-iscc-web-gpu' and extra == 'group-8-iscc-web-dev')" },
+]
+gpu = [
+    { name = "iscc-sci", extra = ["gpu"], marker = "extra == 'extra-8-iscc-web-gpu'" },
+    { name = "iscc-sct", extra = ["gpu"], marker = "extra == 'extra-8-iscc-web-gpu'" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "datamodel-code-generator" },
     { name = "iscc-samples" },
+    { name = "onnxruntime" },
     { name = "poethepoet" },
     { name = "prek" },
     { name = "pytest" },
@@ -1029,6 +1064,10 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28" },
     { name = "iscc-core", specifier = ">=1.2.1" },
     { name = "iscc-lib", specifier = ">=0.4.0" },
+    { name = "iscc-sci", extras = ["cpu"], marker = "extra == 'cpu'", specifier = ">=0.3.0" },
+    { name = "iscc-sci", extras = ["gpu"], marker = "extra == 'gpu'", specifier = ">=0.3.0" },
+    { name = "iscc-sct", extras = ["cpu"], marker = "extra == 'cpu'", specifier = ">=0.2.0" },
+    { name = "iscc-sct", extras = ["gpu"], marker = "extra == 'gpu'", specifier = ">=0.2.0" },
     { name = "iscc-sdk", extras = ["sct", "sci"], specifier = "==0.9.3" },
     { name = "jinja2-simple-tags", specifier = ">=0.6" },
     { name = "pathvalidate", specifier = ">=3.2" },
@@ -1040,11 +1079,13 @@ requires-dist = [
     { name = "watchfiles", specifier = ">=0.21" },
     { name = "xxhash", specifier = ">=3.5" },
 ]
+provides-extras = ["cpu", "gpu"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "datamodel-code-generator", specifier = ">=0.61" },
     { name = "iscc-samples", specifier = ">=0.6" },
+    { name = "onnxruntime" },
     { name = "poethepoet", specifier = ">=0.30" },
     { name = "prek", specifier = ">=0.2.9" },
     { name = "pytest", specifier = ">=8.4" },
@@ -1200,8 +1241,8 @@ name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-8-iscc-web-cpu' and extra == 'extra-8-iscc-web-gpu') or (extra == 'extra-8-iscc-web-gpu' and extra == 'group-8-iscc-web-dev')" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32' or (extra == 'extra-8-iscc-web-cpu' and extra == 'extra-8-iscc-web-gpu') or (extra == 'extra-8-iscc-web-gpu' and extra == 'group-8-iscc-web-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
@@ -1457,6 +1498,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/19/e4/0f9d1a5718b1781c610c1e354765a3820597081754277a6a9a2b50705702/onnxruntime-1.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:31d71a53490e46910877d0902b5ad99c69a5955e5c7ea6c82863519410e1ba7c", size = 13140121, upload-time = "2026-05-08T19:07:57.804Z" },
     { url = "https://files.pythonhosted.org/packages/1c/42/3b8e635f067d06d9f45bede470b8d539d101a4166c272213158dfd08b6ce/onnxruntime-1.26.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7b6d258fb78fdfcf049795bcfaa74dcb90ae7baa277afd21e6fd28b83f2c496", size = 16057240, upload-time = "2026-05-08T19:07:25.163Z" },
     { url = "https://files.pythonhosted.org/packages/93/99/f2be40a31b908d96b861ae0ce98582fa376c18a7f816b9d5eb4cd6aa0a4c/onnxruntime-1.26.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4eefd386a45202aefb7a5132b94f32df9d506c9edcc7faf2fc60d65183f4b183", size = 18197382, upload-time = "2026-05-08T19:07:46.965Z" },
+]
+
+[[package]]
+name = "onnxruntime-gpu"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/97/fe8979f44b9275654b42f7bb556e30789b71a1b22998c83b540df2b1b774/onnxruntime_gpu-1.26.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cfda2fad535595bfc3e570eb588092717711dcb2957656d814695e0c9ceb1508", size = 276974871, upload-time = "2026-05-08T19:15:58.052Z" },
+    { url = "https://files.pythonhosted.org/packages/67/3f/59f1777a394625ecc9a85636de57dc47c25dbb5f888da050f1463955a0ce/onnxruntime_gpu-1.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:6ab9f9c741d2e239b2e321ab0d389c04329d4ab7f11e3b92dd3aa7db1c59dee4", size = 226548083, upload-time = "2026-05-08T19:09:44.408Z" },
+    { url = "https://files.pythonhosted.org/packages/89/96/360328e3c463f7ea08e853c4239c397e83363dd0204de71a710dc1a544bd/onnxruntime_gpu-1.26.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bcf6f347cad9f88a9a625c2b352cf9de927528aedb627ebbc089a201f1990b94", size = 276992052, upload-time = "2026-05-08T19:16:09.892Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c8/aa2dc0e79bba577f37d5448bcb32fea79977e07506684d8138c19a0f1077/onnxruntime_gpu-1.26.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e6e4fb1ec9ae1cf456534d9115f106ab2a1ae96fa513b4ed0f4795302b4a2c6", size = 276978254, upload-time = "2026-05-08T19:16:22.096Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e7/923298431e669567d7ccc2a4c898b6534a47641a051569fd97165fe6d9b8/onnxruntime_gpu-1.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:3e592439b0183d303c2374517b5b392599a3d50b2dc9de949b9b15731ac921c9", size = 229142768, upload-time = "2026-05-08T19:09:54.589Z" },
+    { url = "https://files.pythonhosted.org/packages/97/91/93ffe5431d154989f5e04864a25a97eea480997d771232bcbbc538188241/onnxruntime_gpu-1.26.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56dc7b73954ff4bdc71f5b8ab306b6f61be5d007881b6ef423a609e2b9cd088b", size = 276991545, upload-time = "2026-05-08T19:16:33.347Z" },
 ]
 
 [[package]]
@@ -1997,7 +2057,7 @@ name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coverage" },
+    { name = "coverage", marker = "extra == 'extra-8-iscc-web-cpu' or extra != 'extra-8-iscc-web-gpu' or (extra == 'extra-8-iscc-web-gpu' and extra == 'group-8-iscc-web-dev')" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
@@ -2537,7 +2597,7 @@ name = "tqdm"
 version = "4.68.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-8-iscc-web-cpu' and extra == 'extra-8-iscc-web-gpu') or (extra == 'extra-8-iscc-web-gpu' and extra == 'group-8-iscc-web-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/05/0d5260f1f1ca784f4a4a0def9cbe6affe587f5b4025328d446c3d67765f4/tqdm-4.68.2.tar.gz", hash = "sha256:89c230e8dbc67c7615c142487111222f878c77427ea09549960f62389e258add", size = 171923, upload-time = "2026-06-09T13:26:42.539Z" }
 wheels = [
@@ -2562,7 +2622,7 @@ version = "0.26.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-8-iscc-web-cpu' and extra == 'extra-8-iscc-web-gpu') or (extra == 'extra-8-iscc-web-gpu' and extra == 'group-8-iscc-web-dev')" },
     { name = "rich" },
     { name = "shellingham" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1007,7 +1007,7 @@ wheels = [
 
 [[package]]
 name = "iscc-web"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofile" },


### PR DESCRIPTION
Release **v0.3.1**.

## Changes
- **Opt-in GPU Docker image variant** — published under `-gpu` tags (`:0.3.1-gpu`, `:0.3-gpu`,
  `:main-gpu`) on a CUDA base, running the experimental semantic codes on an NVIDIA GPU. The
  default image stays the lean CPU `python:3.13-slim` build. GPU *deployment* lives in iscc-infra.
- **Tightened client-side ISCC code input validation** in the demo frontend decoder.
- Release bookkeeping: version bump to 0.3.1, CHANGELOG + docs changelog.

## Release mechanics
Merging this triggers `ci.yml` to publish `:main` and `:main-gpu`. Publishing the
`v0.3.1` GitHub release afterward triggers `release.yml` to publish the immutable
`:0.3.1` / `:0.3` (CPU) and `:0.3.1-gpu` / `:0.3-gpu` (GPU) tags. `latest=false` throughout.